### PR TITLE
Payment id for withdraw API method

### DIFF
--- a/src/wrappers/Bittrex.js
+++ b/src/wrappers/Bittrex.js
@@ -386,7 +386,13 @@ class Bittrex {
     if (!address) {
       return Promise.reject(new Error('Address is required'));
     }
-    return this.doRequest(this.ACCOUNT_WITHDRAW, { currency, quantity, address, paymentid });
+    
+    const data = { currency, quantity, address };
+    if (paymentid !== null) {
+      Object.assign(data, paymentid);
+    }
+    
+    return this.doRequest(this.ACCOUNT_WITHDRAW, data);
   }
 
   /**


### PR DESCRIPTION
If `paymentid` isn't sent to `accountWithdraw` function, it appends `paymentid = null` to API call. And API responds with `PAYMENTID_NOT_SUPPORTED` which is not optimal.